### PR TITLE
feat: update DataGather condition when gathering job fails

### DIFF
--- a/pkg/controller/gather_commands.go
+++ b/pkg/controller/gather_commands.go
@@ -160,7 +160,7 @@ func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 	defer cancel()
 	dataGatherCR, err := insightsV1alpha2Cli.DataGathers().Get(ctx, os.Getenv("DATAGATHER_NAME"), metav1.GetOptions{})
 	if err != nil {
-		klog.Errorf("failed to get coresponding DataGather custom resource: %v", err)
+		klog.Errorf("failed to get corresponding DataGather custom resource: %v", err)
 		return err
 	}
 
@@ -204,9 +204,9 @@ func (g *GatherJob) GatherAndUpload(kubeConfig, protoKubeConfig *rest.Config) er
 		configAggregator, insightsHTTPCli)
 	uploader := insightsuploader.New(nil, insightsHTTPCli, configAggregator, nil, nil, 0)
 
-	dataGatherCR, err = status.UpdateProgressingCondition(ctx, insightsV1alpha2Cli, dataGatherCR, status.GatheringReason)
+	dataGatherCR, err = status.UpdateProgressingCondition(ctx, insightsV1alpha2Cli, dataGatherCR, dataGatherCR.Name, status.GatheringReason)
 	if err != nil {
-		klog.Errorf("failed to update coresponding DataGather custom resource: %v", err)
+		klog.Errorf("failed to update corresponding DataGather custom resource: %v", err)
 		return err
 	}
 
@@ -361,7 +361,7 @@ func gatherAndReportFunctions(
 func updateDataGatherStatus(ctx context.Context, insightsClient insightsv1alpha2client.InsightsV1alpha2Interface,
 	dataGatherCR *insightsv1alpha2.DataGather, conditionToUpdate *metav1.Condition, gatheringStatus string,
 ) {
-	dataGatherUpdated, err := status.UpdateProgressingCondition(ctx, insightsClient, dataGatherCR, gatheringStatus)
+	dataGatherUpdated, err := status.UpdateProgressingCondition(ctx, insightsClient, dataGatherCR, dataGatherCR.Name, gatheringStatus)
 	if err != nil {
 		klog.Errorf("Failed to update DataGather resource %s state: %v", dataGatherCR.Name, err)
 	}

--- a/pkg/controller/periodic/periodic.go
+++ b/pkg/controller/periodic/periodic.go
@@ -407,12 +407,10 @@ func (c *Controller) runJobAndCheckResults(ctx context.Context, dataGather *insi
 	klog.Infof("Created new gathering job %v", gj.Name)
 	err = c.jobController.WaitForJobCompletion(ctx, gj)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			klog.Errorf("Failed to read job status: %v", err)
-			return
-		}
-		klog.Error(err)
+		c.handleJobErrors(ctx, dataGather, gj, err)
+		return
 	}
+
 	klog.Infof("Job completed %s", gj.Name)
 	dataGatherFinished, err := c.dataGatherClient.DataGathers().Get(ctx, dataGather.Name, metav1.GetOptions{})
 	if err != nil {
@@ -460,6 +458,28 @@ func (c *Controller) runJobAndCheckResults(ctx context.Context, dataGather *insi
 		return
 	}
 	klog.Info("Operator status in \"insightsoperator.operator.openshift.io\" successfully updated")
+}
+
+// handleJobErrors handles job completion errors and updates DataGather status condition to failed.
+func (c *Controller) handleJobErrors(ctx context.Context, dataGather *insightsv1alpha2.DataGather, job *batchv1.Job, err error) {
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		klog.Errorf("Failed to read job status: %v", err)
+	case errors.Is(err, ErrJobFailed):
+		klog.Errorf("DataGather %s: %v", dataGather.Name, err)
+	default:
+		klog.Errorf("Job %s ended with error: %v", job.Name, err)
+	}
+
+	if _, updateErr := status.UpdateProgressingCondition(
+		ctx,
+		c.dataGatherClient,
+		nil,
+		dataGather.Name,
+		status.GatheringFailedReason,
+	); updateErr != nil {
+		klog.Errorf("failed to update corresponding DataGather custom resource: %v", updateErr)
+	}
 }
 
 // updateStatusBasedOnDataGatherCondition update the Insights ClusterOperator conditions based on the provided


### PR DESCRIPTION
This commit adds functionality to update DataGather progressing condition to GatheringFailed when the
gathering job fails.

<!-- Short description of the PR. What does it do? -->
This PR implements a new data enhancement to...

## Categories
<!-- Select the categories that your PR better fits on -->

- [ ] Bugfix
- [X] Data Enhancement
- [ ] Feature
- [ ] Backporting
- [ ] Others (CI, Infrastructure, Documentation)

## Sample Archive
<!-- Are these changes reflected in sample archive? -->

- `path/to/sample_data.json`

## Documentation
<!-- Are these changes reflected in documentation? -->

- `path/to/documentation.md`

## Unit Tests
<!-- If it includes new unit tests, list them down bellow -->

- `path/to/file_test.go`

## Privacy
<!-- Has data anonymization/privacy been considered by CCX? (e.g. external IP addresses) -->

Yes. There are no sensitive data in the newly collected information.

## Changelog
<!-- Was changelog updated? -->

## Breaking Changes
<!-- Does this PR contain breaking changes? Changes in archive file names or structure for example.
     If so, we should notify other teams using operator's data. -->

Yes/No

## References
<!-- What are related references for this PR? -->

https://issues.redhat.com/browse/???
https://access.redhat.com/solutions/???


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Job failures now mark data gathering as failed and stop further processing.
  - Status updates now succeed even when the resource isn't preloaded, reducing intermittent update failures.
  - Preserves existing start time when gathering is already in progress; fixed a log typo.

- Refactor
  - Unified job error reporting with a single failure indicator and clearer messages.
  - Status update calls now include an explicit resource identifier to improve robustness in async flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->